### PR TITLE
Resource owner nonce

### DIFF
--- a/lib/doorkeeper/openid_connect/models/id_token.rb
+++ b/lib/doorkeeper/openid_connect/models/id_token.rb
@@ -18,7 +18,8 @@ module Doorkeeper
             sub: subject,
             aud: audience,
             exp: expiration,
-            iat: issued_at
+            iat: issued_at,
+            nonce: nonce
           }
         end
 
@@ -55,6 +56,10 @@ module Doorkeeper
 
         def issued_at
           @issued_at.utc.to_i
+        end
+
+        def nonce
+          @resource_owner.nonce if @resource_owner.respond_to?(:nonce)
         end
       end
     end


### PR DESCRIPTION
Trying to deal with a client that expects a nonce returned.

From the [OpenID Connect spec](http://openid.net/specs/openid-connect-core-1_0.html#IDToken)
> nonce
>    String value used to associate a Client session with an ID Token, and to mitigate replay attacks. The value is passed through unmodified from the Authentication Request to the ID Token. If present in the ID Token, Clients MUST verify that the nonce Claim Value is equal to the value of the nonce parameter sent in the Authentication Request. If present in the Authentication Request, Authorization Servers MUST include a nonce Claim in the ID Token with the Claim Value being the nonce value sent in the Authentication Request. Authorization Servers SHOULD perform no other processing on nonce values used. The nonce value is a case sensitive string. 

Right now I'm storing it to resource_owner and monkey patching the Doorkeeper TokensController. Not super fond of this solution. I'm sure there's a better way I just don't have other ideas at the moment. 