### PR TITLE
Handle nil id_tokens

### DIFF
--- a/lib/doorkeeper/openid_connect.rb
+++ b/lib/doorkeeper/openid_connect.rb
@@ -52,9 +52,14 @@ module Doorkeeper
       alias_method :original_body, :body
 
       def body
-        original_body.
-          merge({:id_token => id_token.as_jws_token}).
-          reject { |_, value| value.blank? }
+        if id_token
+          original_body.
+            merge({:id_token => id_token.as_jws_token}).
+            reject { |_, value| value.blank? }
+        else
+          original_body.
+            reject { |_, value| value.blank? }
+        end
       end
     end
   end


### PR DESCRIPTION
Fixes #5 

Certain flows won't have id_tokens associated with them (i.e. client_credentials flow).