### PR TITLE
fix no expiration option error

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ Add the following to your config/initializers/doorkeeper_openid_connect.rb:
         # resource_owner.key
       end
 
+      # Expiration time on or after which the ID Token MUST NOT be accepted for processing. (default 120 seconds).
+      # expiration 600
+
       claims do
         claim :_foo_ do |resource_owner|
           resource_owner.foo
@@ -78,6 +81,11 @@ Given a resource owner, the following claims are required:
 
 * issuer - REQUIRED. Issuer Identifier for the Issuer of the response. The iss value is a case sensitive URL using the https scheme that contains scheme, host, and optionally, port number and path components and no query or fragment components.
 * subject - REQUIRED. Subject Identifier. A locally unique and never reassigned identifier within the Issuer for the End-User, which is intended to be consumed by the Client, e.g., 24400320 or AItOawmwtWwcT0k51BayewNvutrJUqsvl6qs7A4. It MUST NOT exceed 255 ASCII characters in length. The sub value is a case sensitive string.
+
+Exp claim can optionally be specified by expiration configuration.
+
+* exp - REQUIRED. Expiration time on or after which the ID Token MUST NOT be accepted for processing. The processing of this parameter requires that the current date/time MUST be before the expiration date/time listed in the value. Implementers MAY provide for some small leeway, usually no more than a few minutes, to account for clock skew. Its value is a JSON number representing the number of seconds from 1970-01-01T0:0:0Z as measured in UTC until the date/time. See RFC 3339 [RFC3339] for details regarding date/times in general and UTC in particular.
+    * Default 120 seconds
 
 Custom claims can optionally be specified in a `claims` block.  The following claim types are currently supported:
 

--- a/lib/doorkeeper/openid_connect/config.rb
+++ b/lib/doorkeeper/openid_connect/config.rb
@@ -119,6 +119,8 @@ module Doorkeeper
                nil
              end)
 
+      option :expiration, default: 120
+
       option :claims, builder_class: ClaimsBuilder
     end
   end

--- a/spec/lib/doorkeeper/openid_connect/config_spec.rb
+++ b/spec/lib/doorkeeper/openid_connect/config_spec.rb
@@ -53,6 +53,16 @@ describe Doorkeeper::OpenidConnect, 'configuration' do
     end
   end
 
+  describe 'expiration' do
+    it 'sets the value that is accessible via expiration' do
+      value = ''
+      Doorkeeper::OpenidConnect.configure do
+        expiration value
+      end
+      expect(subject.expiration).to eq(value)
+    end
+  end
+
   describe 'claims' do
     it 'sets the claims configuration that is accessible via claims' do
       Doorkeeper::OpenidConnect.configure do


### PR DESCRIPTION
Hi

I have detected `NoMethodError (undefined method expiration for #<Doorkeeper::OpenidConnect::Config:0x007ff85333c4c8>):` error.
So I have added expiration option with default value 120 seconds.

If you have any suitable defaults, could you please inform me it?

Thanks