### PR TITLE
Leave out the kid parameter from the id token headers

### DIFF
--- a/lib/doorkeeper/openid_connect/models/id_token.rb
+++ b/lib/doorkeeper/openid_connect/models/id_token.rb
@@ -31,9 +31,7 @@ module Doorkeeper
         # TODO make signature strategy configurable with keys?
         # TODO move this out of the model
         def as_jws_token
-          Sandal.encode_token(claims, @signer, {
-            kid: @public_key
-          })
+          Sandal.encode_token(claims, @signer, typ: 'JWT')
         end
 
         private

--- a/lib/doorkeeper/openid_connect/version.rb
+++ b/lib/doorkeeper/openid_connect/version.rb
@@ -1,5 +1,5 @@
 module Doorkeeper
   module OpenidConnect
-    VERSION = '1.0.1'
+    VERSION = '1.0.2'
   end
 end


### PR DESCRIPTION
Usually a token recipient will either have the public cert locally or call the JWKS endpoint to retrieve the public cert if the OP supports it.