### PR TITLE
Check the presence of id_token when rendering it in the response body

### DIFF
--- a/lib/doorkeeper/openid_connect.rb
+++ b/lib/doorkeeper/openid_connect.rb
@@ -57,7 +57,7 @@ module Doorkeeper
 
       def body
         original_body.
-          merge({:id_token => id_token.as_jws_token}).
+          merge({:id_token => id_token.try(:as_jws_token)}).
           reject { |_, value| value.blank? }
       end
     end

--- a/lib/doorkeeper/openid_connect/version.rb
+++ b/lib/doorkeeper/openid_connect/version.rb
@@ -1,5 +1,5 @@
 module Doorkeeper
   module OpenidConnect
-    VERSION = '1.0.2'
+    VERSION = '1.0.3'
   end
 end


### PR DESCRIPTION
This will prevent breaking grant types that are not openid connect enabled such as client_credentials.